### PR TITLE
Allow bigger bubble value

### DIFF
--- a/lib/Slider.js
+++ b/lib/Slider.js
@@ -301,9 +301,14 @@ inputRange:[minimumValue,maximumValue],
 outputRange:[0,containerSize.width-thumbSize.width]});
 
 
+
+var currentValueBubbleOverflow=currentValueBubbleSize.width/2-thumbSize.width/2;
+var outputRangeMin=-currentValueBubbleOverflow;
+var outputRangeMax=containerSize.width-(currentValueBubbleSize.width-currentValueBubbleOverflow);
+
 var currentValueBubbleLeft=!!this.props.currentValueBubble&&value.interpolate({
 inputRange:[minimumValue,maximumValue],
-outputRange:[-thumbSize.width/2+4,containerSize.width-currentValueBubbleSize.width+thumbSize.width/2-4]});
+outputRange:[outputRangeMin,outputRangeMax]});
 
 
 var valueVisibleStyle={};
@@ -328,51 +333,51 @@ var graduationArray=[];
 Array(numberOfGraduations).fill(0).forEach(function(value,index){return graduationArray.push(index);});
 
 return(
-_react2.default.createElement(_reactNative.View,{style:this.props.containerStyle,__source:{fileName:_jsxFileName,lineNumber:331}},
-_react2.default.createElement(_reactNative.View,_extends({},other,{style:[mainStyles.container,style],onLayout:this._measureContainer,__source:{fileName:_jsxFileName,lineNumber:332}}),
+_react2.default.createElement(_reactNative.View,{style:this.props.containerStyle,__source:{fileName:_jsxFileName,lineNumber:336}},
+_react2.default.createElement(_reactNative.View,_extends({},other,{style:[mainStyles.container,style],onLayout:this._measureContainer,__source:{fileName:_jsxFileName,lineNumber:337}}),
 _react2.default.createElement(_reactNative.View,{
 style:[{backgroundColor:maximumTrackTintColor},mainStyles.track,trackStyle],
-onLayout:this._measureTrack,__source:{fileName:_jsxFileName,lineNumber:333}}),
-_react2.default.createElement(_reactNative.Animated.View,{style:[mainStyles.track,trackStyle,minimumTrackStyle],__source:{fileName:_jsxFileName,lineNumber:336}}),
+onLayout:this._measureTrack,__source:{fileName:_jsxFileName,lineNumber:338}}),
+_react2.default.createElement(_reactNative.Animated.View,{style:[mainStyles.track,trackStyle,minimumTrackStyle],__source:{fileName:_jsxFileName,lineNumber:341}}),
 
 _react2.default.createElement(_reactNative.Animated.View,{
 onLayout:this._measureThumb,
 style:[
 {backgroundColor:thumbTintColor,marginTop:-(trackSize.height+thumbSize.height)/2},
-mainStyles.thumb,thumbStyle,_extends({left:thumbLeft},valueVisibleStyle)],__source:{fileName:_jsxFileName,lineNumber:338}}),
+mainStyles.thumb,thumbStyle,_extends({left:thumbLeft},valueVisibleStyle)],__source:{fileName:_jsxFileName,lineNumber:343}}),
 
 
 _react2.default.createElement(_reactNative.View,_extends({
 style:[defaultStyles.touchArea,touchOverflowStyle]},
-this._panResponder.panHandlers,{__source:{fileName:_jsxFileName,lineNumber:345}}),
+this._panResponder.panHandlers,{__source:{fileName:_jsxFileName,lineNumber:350}}),
 debugTouchArea===true&&this._renderDebugThumbTouchRect(thumbLeft))),
 
 
 graduationArray.map(function(i){return(
 !ignoredGraduations||!ignoredGraduations.includes(i+1)?
-_react2.default.createElement(_reactNative.View,{key:i,style:{top:containerSize.height/2+trackSize.height/2,position:'absolute'},__source:{fileName:_jsxFileName,lineNumber:353}},
+_react2.default.createElement(_reactNative.View,{key:i,style:{top:containerSize.height/2+trackSize.height/2,position:'absolute'},__source:{fileName:_jsxFileName,lineNumber:358}},
 _react2.default.createElement(_reactNative.View,{
 style:[
 {backgroundColor:maximumTrackTintColor,marginTop:-(trackSize.height+GRADUATION_HEIGHT)/2},
-mainStyles.graduation,graduationStyle,_extends({left:_this2._getGraduationOffset(i)},valueVisibleStyle)],__source:{fileName:_jsxFileName,lineNumber:354}}),
+mainStyles.graduation,graduationStyle,_extends({left:_this2._getGraduationOffset(i)},valueVisibleStyle)],__source:{fileName:_jsxFileName,lineNumber:359}}),
 
 _react2.default.createElement(_reactNative.Animated.View,{
 onLayout:function onLayout(event){return _this2._measureLegend(event,i);},
 style:[mainStyles.graduationLabel,graduationLabelContainerStyle,
-{width:_this2.state.legendWidth[i],left:_this2._getGraduationOffset(i)-_this2.state.legendWidth[i]/2}],__source:{fileName:_jsxFileName,lineNumber:359}},
+{width:_this2.state.legendWidth[i],left:_this2._getGraduationOffset(i)-_this2.state.legendWidth[i]/2}],__source:{fileName:_jsxFileName,lineNumber:364}},
 _this2._renderGraduationLabel(i))):
 
 showBarAtIgnoredGraduation&&
-_react2.default.createElement(_reactNative.View,{key:i,style:{top:containerSize.height/2+trackSize.height/2,position:'absolute'},__source:{fileName:_jsxFileName,lineNumber:366}},
-_react2.default.createElement(_reactNative.View,{style:_extends({backgroundColor:maximumTrackTintColor,marginTop:-(trackSize.height+GRADUATION_HEIGHT-2)/2,width:2,height:GRADUATION_HEIGHT-2,left:_this2._getGraduationOffset(i)},valueVisibleStyle),__source:{fileName:_jsxFileName,lineNumber:367}})));}),
+_react2.default.createElement(_reactNative.View,{key:i,style:{top:containerSize.height/2+trackSize.height/2,position:'absolute'},__source:{fileName:_jsxFileName,lineNumber:371}},
+_react2.default.createElement(_reactNative.View,{style:_extends({backgroundColor:maximumTrackTintColor,marginTop:-(trackSize.height+GRADUATION_HEIGHT-2)/2,width:2,height:GRADUATION_HEIGHT-2,left:_this2._getGraduationOffset(i)},valueVisibleStyle),__source:{fileName:_jsxFileName,lineNumber:372}})));}),
 
 
 
 !!this.props.currentValueBubble&&!!this.props.graduationLabel&&
 _react2.default.createElement(_reactNative.Animated.View,{
 onLayout:this._measureCurrentValueBubble,
-style:[{top:containerSize.height/2-trackSize.height-thumbSize.height-4},mainStyles.currentValueBubbleContainer,currentValueBubbleContainerStyle,_extends({left:currentValueBubbleLeft},valueVisibleStyle)],__source:{fileName:_jsxFileName,lineNumber:372}},
-_react2.default.createElement(_reactNative.Text,{style:[mainStyles.currentValueBubble,currentValueBubbleTextStyle],__source:{fileName:_jsxFileName,lineNumber:375}},this.props.graduationLabel(this.props.value)))));
+style:[{top:containerSize.height/2-trackSize.height-thumbSize.height-4},mainStyles.currentValueBubbleContainer,currentValueBubbleContainerStyle,_extends({left:currentValueBubbleLeft},valueVisibleStyle)],__source:{fileName:_jsxFileName,lineNumber:377}},
+_react2.default.createElement(_reactNative.Text,{style:[mainStyles.currentValueBubble,currentValueBubbleTextStyle],__source:{fileName:_jsxFileName,lineNumber:380}},this.props.graduationLabel(this.props.value)))));
 
 
 
@@ -647,12 +652,12 @@ props.thumbTouchSize.height);
 _renderGraduationLabel=function(index){
 if(_this3.props.graduationLabel){
 return(
-_react2.default.createElement(_reactNative.Text,{style:[{textAlign:'center'},_this3.props.graduationLabelStyle],__source:{fileName:_jsxFileName,lineNumber:650}},
+_react2.default.createElement(_reactNative.Text,{style:[{textAlign:'center'},_this3.props.graduationLabelStyle],__source:{fileName:_jsxFileName,lineNumber:655}},
 _this3.props.graduationLabel(index)));
 
 
 }
-return _react2.default.createElement(_reactNative.View,{__source:{fileName:_jsxFileName,lineNumber:655}});
+return _react2.default.createElement(_reactNative.View,{__source:{fileName:_jsxFileName,lineNumber:660}});
 };this.
 
 _renderDebugThumbTouchRect=function(thumbLeft){
@@ -667,7 +672,7 @@ height:thumbTouchRect.height};
 return(
 _react2.default.createElement(_reactNative.Animated.View,{
 style:[defaultStyles.debugThumbTouchArea,positionStyle],
-pointerEvents:'none',__source:{fileName:_jsxFileName,lineNumber:668}}));
+pointerEvents:'none',__source:{fileName:_jsxFileName,lineNumber:673}}));
 
 
 };};

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -301,9 +301,14 @@ class Slider extends React.Component {
       outputRange: [0, containerSize.width - thumbSize.width],
       //extrapolate: 'clamp',
     });
+
+    const currentValueBubbleOverflow = currentValueBubbleSize.width / 2 - thumbSize.width / 2;
+    const outputRangeMin = -currentValueBubbleOverflow;
+    const outputRangeMax = containerSize.width - (currentValueBubbleSize.width - currentValueBubbleOverflow);
+
     const currentValueBubbleLeft = !!this.props.currentValueBubble && value.interpolate({
       inputRange: [minimumValue, maximumValue],
-      outputRange: [-thumbSize.width / 2 + 4, containerSize.width - currentValueBubbleSize.width + thumbSize.width / 2 - 4],
+      outputRange: [outputRangeMin, outputRangeMax],
     });
 
     var valueVisibleStyle = {};


### PR DESCRIPTION
## Problem

When bubble value is bigger than the default width, label appears on 2 lines : 
![image](https://user-images.githubusercontent.com/9041221/53230687-83b9fd80-3687-11e9-9d08-0220f22df7ba.png)

If we change bubble width with props currentValueBubbleContainerStyle, label is not correctly animated : bubble center doesn't follow correctly thumb center.

## Solution

This PR improve calculation of left ccs property of bubble.

![image](https://user-images.githubusercontent.com/9041221/53230914-1c507d80-3688-11e9-96b8-acabe99cc3fa.png)

